### PR TITLE
Allow for overwrites of caching behavior

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -215,7 +215,7 @@ abstract class Reader implements IReader {
 	 * @param array $dataSets
 	 * @return void
 	 */
-	private function cacheResults( string $hash, array $dataSets ): void {
+	protected function cacheResults( string $hash, array $dataSets ): void {
 		$cache = $this->cacheFactory->getLocalServerInstance();
 		$key = $cache->makeKey( 'datastore', 'reader', 'query', $hash );
 		$cache->set( $key, $dataSets, static::CACHE_TTL );
@@ -225,7 +225,7 @@ abstract class Reader implements IReader {
 	 * @param ReaderParams $params
 	 * @return string
 	 */
-	private function getQueryId( ReaderParams $params ): string {
+	protected function getQueryId( ReaderParams $params ): string {
 		return md5( get_class( $this ) . $params->getHash() );
 	}
 
@@ -234,7 +234,7 @@ abstract class Reader implements IReader {
 	 * @param array $buckets
 	 * @return void
 	 */
-	private function cacheBuckets( string $queryId, array $buckets ) {
+	protected function cacheBuckets( string $queryId, array $buckets ) {
 		$cache = $this->cacheFactory->getLocalServerInstance();
 		$key = $cache->makeKey( 'datastore', 'reader', 'buckets', $queryId );
 		$cache->set( $key, $buckets, static::CACHE_TTL );
@@ -244,7 +244,7 @@ abstract class Reader implements IReader {
 	 * @param string $queryId
 	 * @return array|null
 	 */
-	private function tryGetBucketsFromCache( string $queryId ) {
+	protected function tryGetBucketsFromCache( string $queryId ) {
 		// Due to issues with the cache invalidation, we disable this code
 		// But we keep it for improvement in the next release
 		return null;


### PR DESCRIPTION
The `Reader` is a base class and should allow sub classes to alter the default caching behavior.

[5.2.x]